### PR TITLE
Update Scrabble-doc-fr.tex

### DIFF
--- a/doc/Scrabble-doc-fr.tex
+++ b/doc/Scrabble-doc-fr.tex
@@ -22,7 +22,7 @@
 \lfoot{\sffamily\small [Scrabble]}
 \cfoot{\sffamily\small - \thepage{} -}
 \rfoot{\hyperlink{matoc}{\small\faArrowAltCircleUp[regular]}}
-
+\usepackage{microtype}
 %\usepackage{hvlogos}
 \usepackage{hologo}
 \providecommand\tikzlogo{Ti\textit{k}Z}
@@ -40,7 +40,7 @@
 		& & & & & {\huge \hologo{MiKTeX}} \\
 	\end{tblr}
 }
-
+\usepackage[hyphens]{url}
 \usepackage{hyperref}
 \urlstyle{same}
 \hypersetup{pdfborder=0 0 0}
@@ -115,7 +115,7 @@
 
 \smallskip
 
-{$\blacktriangleright$~~Possibilité de mettre le plateau et les points pour les versions Française, Anglaise, Allemande et Espagnole.}
+{$\blacktriangleright$~~Possibilité de mettre le plateau et les points pour les versions française, anglaise, allemande et espagnole.}
 
 \smallskip
 
@@ -172,7 +172,7 @@
 
 \subsection{Source}
 
-Certaines idées viennent de \url{https://tex.stackexchange.com/questions/194780/tikz-drawing-a-rectangle-with-spikes-on-borders}, avec une proposition de Mark Wibrow.
+Certaines idées viennent de la page \url{https://tex.stackexchange.com/questions/194780/tikz-drawing-a-rectangle-with-spikes-on-borders}, avec une proposition de Mark Wibrow.
 
 \smallskip
 
@@ -273,7 +273,7 @@ Pour le placement des mots :
 \begin{itemize}
 	\item le premier argument, \textit{optionnel}, entre \texttt{[...]} est l'orientation du mot, à choisir entre \Cle{H} (par défaut) et \Cle{V} (en fait toute autre lettre que \Cle{H} !) ;
 	\item le deuxième argument, \textit{obligatoire}, entre \texttt{\{...\}}, est le mot à placer, en majuscules ou minuscules ;
-	\item le dernier argument, \textit{obligatoire}, entre \texttt{\{...\}}, correspond aux coordonnées de la case sur laquelle sera placée le début du mot (la case (1;\,1) étant la case au bord Bas/Gauche).
+	\item le dernier argument, \textit{obligatoire}, entre \texttt{\{...\}}, correspond aux coordonnées de la case sur laquelle sera placée le début du mot (la case (1\,,\,1) étant la case au bord Bas/Gauche).
 \end{itemize}
 
 \textbf{Remarque 1 :} la langue choisie permettra également d'avoir les jetons avec le \textit{bon} nombre de points !


### PR DESCRIPTION
Ligne 118 : « Français » etc. sont ici des adjectifs, donc en minuscule (cf. la différence : un Français, une personne française). 
Ligne 175 : pour éviter le dépassement dans la marge de l'url, j'ajoute le texte « la page » ce qui placera l'un des tirets très proche du bord de la marge, et en ligne 43 j'ajoute le chargement du package `url` avec l'option `[hyphens]` autorisant la coupure aux tirets. `hyperref` tiendra compte de cette option du package `url` pour la commande `\url`. Enfin, comme malgré tout le tiret déborde très légèrement sur la marge (voir le overful hbox sans cela), je charge `microtype` pour un ajustement fin des espacements entre les mots. 
Ligne 276, je remplace (1;1) par (1,1) car la syntaxe demande une virgule comme séparateur (même si en maths françaises, on utilise le `;`. Peut-être qu'en composant (1,1) en code à chasse fixe, on comprendra mieux que c'est du code informatique qu'il s'agit ici). Cette dernière correction est aussi à transposer dans la version anglaise de la documentation.